### PR TITLE
BA: fix turtling zigzags and advanced factory build

### DIFF
--- a/data/ai/BA/buildhandler.lua
+++ b/data/ai/BA/buildhandler.lua
@@ -377,19 +377,19 @@ function BuildSiteHandler:CheckForDuplicates(unitName)
 	local isFactory = utable.isBuilding and utable.buildOptions
 	local isExpensive = utable.metalCost > 300
 	if not isFactory and not isExpensive then return false end
-	EchoDebugPlans("looking for duplicate plan")
+	EchoDebugPlans("looking for duplicate plan for " .. unitName)
 	for i, plan in pairs(self.plans) do
 		local thisIsFactory = unitTable[plan.unitName].isBuilding and unitTable[plan.unitName].buildOptions
 		if isFactory and thisIsFactory then return true end
 		if isExpensive and plan.unitName == unitName then return true end
 	end
-	EchoDebugPlans("looking for duplicate construction")
+	EchoDebugPlans("looking for duplicate construction for " .. unitName)
 	for unitID, construct in pairs(self.constructing) do
 		local thisIsFactory = unitTable[construct.unitName].isBuilding and unitTable[construct.unitName].buildOptions
 		if isFactory and thisIsFactory then return true end
 		if isExpensive and construct.unitName == unitName then return true end
 	end
-	EchoDebugPlans("looking for duplicate history")
+	EchoDebugPlans("looking for duplicate history " .. unitName)
 	if isFactory then
 		-- look through history for factories built recently
 		local f = game:Frame()
@@ -402,6 +402,7 @@ function BuildSiteHandler:CheckForDuplicates(unitName)
 			if thisIsFactory then
 				if f < done.frame + 600 then
 					-- don't build factories within 20 seconds of one another
+					EchoDebug("found a factory too recently")
 					return true
 				end
 			end

--- a/data/ai/BA/factoryregisterbehaviour.lua
+++ b/data/ai/BA/factoryregisterbehaviour.lua
@@ -27,8 +27,8 @@ end
 function FactoryRegisterBehaviour:UnitBuilt(unit)
 	-- don't add factories to factory location table until they're done
 	if unit.engineID == self.unit.engineID then
-		self:Register()
 		self.finished = true
+		self:Register()
 	end
 end
 
@@ -95,6 +95,7 @@ function FactoryRegisterBehaviour:Register()
 	-- register maximum factory level
     local un = self.name
     local level = self.level
+    EchoDebug("factory " .. un .. " level " .. level .. " registering")
 	if ai.factoriesAtLevel[level] == nil then
 		ai.factoriesAtLevel[level] = {}
 	end

--- a/data/ai/BA/taskqueuebehaviour.lua
+++ b/data/ai/BA/taskqueuebehaviour.lua
@@ -96,8 +96,8 @@ function TaskQueueBehaviour:CategoryEconFilter(value)
 			if ai.factories - ai.outmodedFactories <= 0 and metalOkay and energyOkay and Metal.income > 3 and Metal.reserves > unitTable[value].metalCost * 0.7 then
 				EchoDebug("   first factory")
 				-- build the first factory
-			elseif advFactories[value] and (ai.factoriesAtLevel[3] == nil or ai.factoriesAtLevel[3] == {}) and metalOkay and energyOkay then
-				-- easily build advanced factory only if it's the first one
+			elseif advFactories[value] and metalOkay and energyOkay then
+				-- build advanced factory
 			elseif expFactories[value] and metalOkay and energyOkay then
 				-- build experimental factory
 			elseif ai.couldAttack - ai.factories >= 1 or ai.couldBomb - ai.factories >= 1 then

--- a/data/ai/BA/taskqueues.lua
+++ b/data/ai/BA/taskqueues.lua
@@ -162,6 +162,7 @@ function CheckForMapControl()
 			ai.needNukes = true
 		end
 		EchoDebug("metal income: " .. Metal.income .. "  combat units: " .. ai.combatCount)
+		EchoDebug("have advanced? " .. tostring(ai.haveAdvFactory) .. " have experimental? " .. tostring(ai.haveExpFactory))
 		EchoDebug("need advanced? " .. tostring(ai.needAdvanced) .. "  need experimental? " .. tostring(ai.needExperimental))
 	end
 end

--- a/data/ai/BA/unitlists.lua
+++ b/data/ai/BA/unitlists.lua
@@ -153,21 +153,28 @@ helpList = {
 	armuwmme = 2,
 }
 
--- things to defend with defense towers other than factories
--- value is priority
+-- priorities of things to defend that can't be accounted for by the formula in turtlehandler
 turtleList = {
-	aafus = 8,
-	cafus = 8,
-	corfus = 5,
-	armfus = 5,
-	cmgeo = 4,
-	amgeo = 4,
-	corgeo = 3,
-	armgeo = 3,
-	cormoho = 2,
-	armmoho = 2,
-	cormex = 1,
-	armmex = 1,
+	cormakr = 0.5,
+	armmakr = 0.5,
+	corfmkr = 0.5,
+	armfmkr = 0.5,
+	cormmkr = 4,
+	armmmkr = 4,
+	coruwmmm = 4,
+	armuwmmm = 4,
+	corestor = 0.5,
+	armestor = 0.5,
+	cormstor = 0.5,
+	armmstor = 0.5,
+	coruwes = 0.5,
+	armuwes = 0.5,
+	coruwms = 0.5,
+	armuwms = 0.5,
+	coruwadves = 2,
+	armuwadves = 2,
+	coruwadvms = 2,
+	armuwadvms = 2,
 }
 
 -- factories that can build advanced construction units (i.e. moho mines)


### PR DESCRIPTION
- create formula for turtle organ priority
- quasidefense count as organs too (so for example radar towers will get
  more defense)
- fix advanced factory not being built again after one is destroyed
- fix excessive base defense to mex zigzagging in turtlehandler
  (distance mult too high)
- only build quasidefense (radar, sonar, jammer, etc) at already
  defended turtles
